### PR TITLE
Add custom delimiter option

### DIFF
--- a/Generator.js
+++ b/Generator.js
@@ -71,7 +71,7 @@ function parseId(id) {
   }
 }
 
-function generateId(letters, numLetters, numbers, numNumbers) {
+function generateId(letters, numLetters, numbers, numNumbers, delimiter) {
   if (numLetters > 0 && numNumbers <= 0) {
     var nextLetters = incrementLetters(letters);
     var id = fillLetters(nextLetters, numLetters);
@@ -89,7 +89,7 @@ function generateId(letters, numLetters, numbers, numNumbers) {
       nextLetters = incrementLetters(letters);
     }
     var id = fillLetters(nextLetters, numLetters)
-      + " - " + fillZeros(nextNumber, numNumbers);
+      + " " + delimiter + " " + fillZeros(nextNumber, numNumbers);
     return {id: id, letters: nextLetters, numbers: nextNumber};
   }
 }
@@ -98,6 +98,11 @@ function int(_var, _default) {
   if (typeof(_var) === "undefined") return _default;
   var _int = parseInt(_var);
   return isNaN(_int) ? _default : _int;
+}
+
+function delimter(_var, _default) {
+  if (typeof(_var) === "undefined") return _default;
+  return /^[/\-:,.%"'+=&*#@~!;^`]$/.test(_var) ? _var : _default;
 }
 
 var Generator = (function() {
@@ -120,6 +125,7 @@ var Generator = (function() {
     this.keys[key].options = {};
     this.keys[key].options.digits = int(options.digits, 6);
     this.keys[key].options.letters = int(options.letters, 3);
+    this.keys[key].options.delimiter = delimter(options.delimiter, "-");
     this.keys[key].options.store = typeof(options.store) === "function"
       ? options.store : function() {}
     this.keys[key].options.store_freq = int(options.store_freq, 1);
@@ -155,7 +161,7 @@ var Generator = (function() {
       this.add(key);
     }
     var _new = generateId(this.keys[key].letters, this.keys[key].options.letters,
-      this.keys[key].numbers, this.keys[key].options.digits);
+      this.keys[key].numbers, this.keys[key].options.digits, this.keys[key].options.delimiter);
     this.keys[key].letters = _new.letters;
     this.keys[key].numbers = _new.numbers;
     this.keys[key].generatedIds.push(_new.id);

--- a/Generator.js
+++ b/Generator.js
@@ -89,7 +89,7 @@ function generateId(letters, numLetters, numbers, numNumbers, delimiter) {
       nextLetters = incrementLetters(letters);
     }
     var id = fillLetters(nextLetters, numLetters)
-      + " " + delimiter + " " + fillZeros(nextNumber, numNumbers);
+      + delimiter + fillZeros(nextNumber, numNumbers);
     return {id: id, letters: nextLetters, numbers: nextNumber};
   }
 }
@@ -102,7 +102,7 @@ function int(_var, _default) {
 
 function delimter(_var, _default) {
   if (typeof(_var) === "undefined") return _default;
-  return /^[/\-:,.%"'+=&*#@~!;^`]$/.test(_var) ? _var : _default;
+  return /^\s|[\/\-:,.%"'+=&*#@~!;^`]|\s/.test(_var) ? _var : _default;
 }
 
 var Generator = (function() {
@@ -125,7 +125,7 @@ var Generator = (function() {
     this.keys[key].options = {};
     this.keys[key].options.digits = int(options.digits, 6);
     this.keys[key].options.letters = int(options.letters, 3);
-    this.keys[key].options.delimiter = delimter(options.delimiter, "-");
+    this.keys[key].options.delimiter = delimter(options.delimiter, " - ");
     this.keys[key].options.store = typeof(options.store) === "function"
       ? options.store : function() {}
     this.keys[key].options.store_freq = int(options.store_freq, 1);

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ npm install sequential-ids --save
 var sequential = require("sequential-ids");
 
 var generator = new sequential.Generator({
-  digits: 6, letters: 3,
+  digits: 6, letters: 3, delimiter: "/",
   store: function(key, ids) {
     db.store(key, ids[ids.length - 1]);
   },
@@ -51,17 +51,17 @@ generator.add('otherKey', {
 });
 
 generator.start();
-var new_id_1   = generator.generate();           // => AAB - 001
-var new_id_2   = generator.generate();           // => AAB - 002
+var new_id_1   = generator.generate();           // => AAB / 000001
+var new_id_2   = generator.generate();           // => AAB / 000002
 // ...
-var other_id_1 = generator.generate('otherKey'); // => A - 01
+var other_id_1 = generator.generate('otherKey'); // => A  01
 var other_id_2 = generator.generate('otherKey'); // => A - 02
 // ...
 
 // possibly in another file
 var accessor = new sequential.Accessor();
 accessor.next(function(err, id) {
-  console.log("new id: %s", id); // => AAB - 003
+  console.log("new id: %s", id); // => AAB / 000003
 });
 
 accessor.next('otherKey',function(err, id) {
@@ -117,6 +117,9 @@ accessor.next('otherKey',function(err, id) {
             * no. of letters to use.
             * assigning `0` (zero) lets you ignore the letters part
             * Defaults to `3`.
+        * `delimiter`:
+            * delimiter to use between digits and letters.
+            * Defaults to `-`.            
         * `store`:
             * a function that will be called to store the IDs on disk for
               persistence.


### PR DESCRIPTION
Users can now choose "sane" delimiter options such as:
`"~", "+", "/", "#"`, among others.

Sticking with old ES5 syntax for forming strings.

Regex limits delimiters to certain sane delimiter values i.e. https://en.wikipedia.org/wiki/Delimiter-separated_values

Defaults to `"-"`

I think project is kinda old but we can add a tiny feature to it, probably not very useful though.